### PR TITLE
feat: loadAllModulesInDirectory with pattern option

### DIFF
--- a/src/core/structures/Registry.ts
+++ b/src/core/structures/Registry.ts
@@ -91,10 +91,10 @@ export class Registry {
     }
   }
 
-  async loadAllModulesInDirectory(dir: string): Promise<object[]> {
+  async loadAllModulesInDirectory(dir: string, pattern?: RegExp): Promise<object[]> {
     const results: object[] = []
 
-    const files = walkSync(dir).filter((x) => x.endsWith('.ts') || x.endsWith('.js'))
+    const files = walkSync(dir).filter((x) => (x.endsWith('.ts') || x.endsWith('.js')) && (!pattern || pattern.test(x)))
 
     for (const file of files) {
       if (file.endsWith('.d.ts')) continue


### PR DESCRIPTION
This PR adds new feature that can use regex pattern on `Registry.loadAllModulesInDirectory` method.

기존 command.ts에서는 `loadAllModulesInDirectory`를 통해 모듈을 로드할 경우 그 안에 익스텐션으로서 올바르지 않은 타입스크립트 또는 자바스크립트 파일이 있지 않을 경우 오류가 발생합니다. 이 자체는 좋지만, nest.js-like와 같은 다른 패턴으로 구조를 구축하려는 개발자들에게 이러한 오류 처리는 불편할 수 있습니다. 이 문제를 이 PR은 `loadAllModulesInDirectory`에 RegExp 타입의 pattern 옵션을 추가함을 통해 해결합니다. 이는 이 프레임워크를 사용하는 개발자의 자유를 늘려 줍니다.

`pattern` 옵션은 선택사항으로, 값을 주지 않을 경우 기존과 동일하게 작동합니다.